### PR TITLE
for eventhubcapture publisher, require a connectionstring

### DIFF
--- a/src/EventGridExtension/DefaultPublisher.cs
+++ b/src/EventGridExtension/DefaultPublisher.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
 {
@@ -33,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
             }
         }
 
-        public Dictionary<string, object> ExtractBindingData(EventGridEvent e, Type t)
+        public Task<Dictionary<string, object>> ExtractBindingData(EventGridEvent e, Type t)
         {
             var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             if (t == typeof(EventGridEvent))
@@ -45,13 +46,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
                 bindingData.Add("EventGridTrigger", JsonConvert.SerializeObject(e, Formatting.Indented));
             }
 
-            return bindingData;
+            return Task.FromResult<Dictionary<string, object>>(bindingData);
         }
 
         public object GetArgument(Dictionary<string, object> bindingData)
         {
             return bindingData["EventGridTrigger"];
         }
-
     }
+
 }

--- a/src/EventGridExtension/EventGridTriggerAttribute.cs
+++ b/src/EventGridExtension/EventGridTriggerAttribute.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
             Publisher = publisher;
         }
 
+        public string Connection { get; set; } = null;
         public string Publisher { get; }
     }
 }

--- a/src/EventGridExtension/EventGridTriggerAttributeBindingProvider.cs
+++ b/src/EventGridExtension/EventGridTriggerAttributeBindingProvider.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
             }
             else if (String.Equals(publisherName, EventHubCapturePublisher.Name, StringComparison.OrdinalIgnoreCase))
             {
-                publisher = new EventHubCapturePublisher();
+                // if publisher is EventHubCapture, Connection String is going to be required
+                publisher = new EventHubCapturePublisher(attribute.Connection);
             }
 
             var contract = publisher?.ExtractBindingContract(parameter.ParameterType);
@@ -92,12 +93,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
                 get { return typeof(EventGridEvent); }
             }
 
-            public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
+            public async Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
             {
                 EventGridEvent triggerValue = value as EventGridEvent;
-                var bindingData = _publisher.ExtractBindingData(triggerValue, _parameter.ParameterType);
+                var bindingData = await _publisher.ExtractBindingData(triggerValue, _parameter.ParameterType);
                 IValueBinder valueBinder = new EventGridValueBinder(_parameter, _publisher.GetArgument(bindingData), _publisher.Recycles);
-                return Task.FromResult<ITriggerData>(new TriggerData(valueBinder, bindingData));
+                return new TriggerData(valueBinder, bindingData);
             }
 
             public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)

--- a/src/EventGridExtension/IPublisher.cs
+++ b/src/EventGridExtension/IPublisher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
 {
@@ -13,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
         // return null
         Dictionary<string, Type> ExtractBindingContract(Type t);
 
-        Dictionary<string, object> ExtractBindingData(EventGridEvent e, Type t);
+        Task<Dictionary<string, object>> ExtractBindingData(EventGridEvent e, Type t);
 
         object GetArgument(Dictionary<string, object> bindingData);
     }

--- a/src/EventGridExtension/TestListener.cs
+++ b/src/EventGridExtension/TestListener.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
   'eventTime': '2017-07-14T23:10:27.7689666Z',
   'id': '7b11c4ce-1c34-4416-848b-1730e766f126',
   'data': {
-    'fileUrl': 'https://shunsouthcentralus.blob.core.windows.net/archivecontainershun/canaryeh/test/1/2017/07/14/23/09/27.avro',
+    'fileUrl': 'https://shunsouthcentralus.blob.core.windows.net/debugging/shunBlob.txt',
     'fileType': 'AzureBlockBlob',
     'partitionId': '1',
     'sizeInBytes': 0,

--- a/test/localTests/EventGridBinding.csproj
+++ b/test/localTests/EventGridBinding.csproj
@@ -3,6 +3,9 @@
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.EventGrid.Test</PackageId>
     <Description></Description>
+    <ApplicationIcon />
+    <OutputType>Exe</OutputType>
+    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EventGridExtension\EventGridExtension.csproj" />

--- a/test/localTests/Function.cs
+++ b/test/localTests/Function.cs
@@ -13,16 +13,24 @@ namespace EventGridBinding
             Console.WriteLine(value);
         }
 
-        public void TestInputStream([EventGridTrigger("eventhubcapture")] Stream myBlob, string blobTrigger)
+        public void TestInputStream([EventGridTrigger("eventhubcapture", Connection = "ShunTestConnectionString")] Stream myBlob, string blobTrigger)
         {
             Console.WriteLine($"file name {blobTrigger}");
             var reader = new StreamReader(myBlob);
-            string line = null;
-            while (!string.IsNullOrEmpty(line = reader.ReadLine()))
+            Console.WriteLine(reader.ReadToEnd());
+        }
+
+        public void TestByteArray([EventGridTrigger("eventhubcapture", Connection = "ShunTestConnectionString")] byte[] myBlob)
+        {
+            foreach (var b in myBlob)
             {
-                Console.WriteLine(line);
+                Console.Write(b);
             }
         }
 
+        public void TestString([EventGridTrigger("eventhubcapture", Connection = "ShunTestConnectionString")] string myBlob)
+        {
+            Console.WriteLine(myBlob);
+        }
     }
 }

--- a/test/localTests/Program.cs
+++ b/test/localTests/Program.cs
@@ -14,18 +14,10 @@ namespace EventGridBinding
                 config.UseDevelopmentSettings();
             }
 
-            var ext = new EventGridExtensionConfig();
-            config.AddExtension(ext);
-
-            //config.TypeLocator = new ;
-            //config.JobActivator = new ;
-
-            Function prog = new Function();
+            config.UseEventGrid();
 
             JobHost host = new JobHost(config);
             host.RunAndBlock();
-
-            
         }
     }
 }


### PR DESCRIPTION
Exception if using capture publisher but did not specify connectionString

![image](https://user-images.githubusercontent.com/6531400/28765978-426df376-7582-11e7-942b-c806480b3ad2.png)

Expected function.json
```
{
  "bindings": [
    {
      "type": "EventGridTrigger",
      "name": "myBlob",
      "direction": "in",
      "publisher": "eventhubcapture",
      "connection": "privateStorage"
    }
  ],
  "disabled": false
}

```

output difference:
before change
```
2017-07-31T06:37:25.482 Function started (Id=3346b2ee-807c-4aba-8a22-43b06d9f0be0)
2017-07-31T06:37:25.732 file name archivecontainershun/canaryeh/test/0/2017/07/31/06/36/27.avro
2017-07-31T06:37:25.732 blobName canaryeh/test/0/2017/07/31/06/36/27.avro
2017-07-31T06:37:25.732 metadata System.Collections.Generic.Dictionary`2[System.String,System.String]
2017-07-31T06:37:25.986 Function completed (Failure, Id=3346b2ee-807c-4aba-8a22-43b06d9f0be0, Duration=512ms)
2017-07-31T06:37:27.635 Exception while executing function: Functions.EventGridTrigger-Test. mscorlib: Exception has been thrown by the target of an invocation. Microsoft.WindowsAzure.Storage: The remote server returned an error: (404) Not Found. System: The remote server returned an error: (404) Not Found.
```

after change
```
2017-07-31T06:43:05.450 Function started (Id=6ffd80bd-1774-4f99-b243-85cd5e8dcb11)
2017-07-31T06:43:05.450 file name archivecontainershun/canaryeh/test/0/2017/07/31/06/41/27.avro
2017-07-31T06:43:05.450 blobName canaryeh/test/0/2017/07/31/06/41/27.avro
2017-07-31T06:43:05.450 metadata System.Collections.Generic.Dictionary`2[System.String,System.String]
2017-07-31T06:43:05.529 Objavro.codecnullavro.schema�{"type":"record","name":"EventData","namespace":"Microsoft.ServiceBus.Messaging","fields":[{"name":"SequenceNumber","type":"long"},{"name":"Offset","type":"string"},{"name":"EnqueuedTimeUtc","type":"string"},{"name":"SystemProperties","type":{"type":"map","values":["long","double","string","bytes"]}},{"name":"Properties","type":{"type":"map","values":["long","double","string","bytes","null"]}},{"name":"Body","type":["null","bytes"]}]} ���#΁M�1��  ���#΁M�1��
2017-07-31T06:43:05.529 Function completed (Success, Id=6ffd80bd-1774-4f99-b243-85cd5e8dcb11, Duration=90ms)
```