### PR TITLE
allow user to pass test data in function portal

### DIFF
--- a/src/EventGridExtension/AssemblyInfo.cs
+++ b/src/EventGridExtension/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests")]

--- a/src/EventGridExtension/EventGridTriggerAttributeBindingProvider.cs
+++ b/src/EventGridExtension/EventGridTriggerAttributeBindingProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
             return (t == typeof(EventGridEvent) || t == typeof(string));
         }
 
-        private class EventGridTriggerBinding : ITriggerBinding
+        internal class EventGridTriggerBinding : ITriggerBinding
         {
             private readonly ParameterInfo _parameter;
             private readonly Dictionary<string, Type> _bindingContract;
@@ -89,7 +89,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
                 EventGridEvent triggerValue = null;
                 if (value is string)
                 {
-                    triggerValue = JsonConvert.DeserializeObject<EventGridEvent>((string)value);
+                    try
+                    {
+                        triggerValue = JsonConvert.DeserializeObject<EventGridEvent>((string)value);
+                    }
+                    catch (Exception)
+                    {
+                        throw new FormatException($"Unable to parse {value} to {typeof(EventGridEvent)}");
+                    }
+
                 }
                 else
                 {

--- a/src/EventGridExtension/EventGridTriggerAttributeBindingProvider.cs
+++ b/src/EventGridExtension/EventGridTriggerAttributeBindingProvider.cs
@@ -87,20 +87,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
             {
                 // convert value to EventGridEvent, extract {data} as JObject
                 EventGridEvent triggerValue = null;
-                if (value is string)
+                if (value is string stringValue)
                 {
                     try
                     {
-                        triggerValue = JsonConvert.DeserializeObject<EventGridEvent>((string)value);
+                        triggerValue = JsonConvert.DeserializeObject<EventGridEvent>(stringValue);
                     }
                     catch (Exception)
                     {
-                        throw new FormatException($"Unable to parse {value} to {typeof(EventGridEvent)}");
+                        throw new FormatException($"Unable to parse {stringValue} to {typeof(EventGridEvent)}");
                     }
 
                 }
                 else
                 {
+                    // default casting
                     triggerValue = value as EventGridEvent;
                 }
 

--- a/src/EventGridExtension/EventGridTriggerAttributeBindingProvider.cs
+++ b/src/EventGridExtension/EventGridTriggerAttributeBindingProvider.cs
@@ -85,7 +85,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
 
             public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
             {
-                EventGridEvent triggerValue = value as EventGridEvent;
+                // convert value to EventGridEvent, extract {data} as JObject
+                EventGridEvent triggerValue = null;
+                if (value is string)
+                {
+                    triggerValue = JsonConvert.DeserializeObject<EventGridEvent>((string)value);
+                }
+                else
+                {
+                    triggerValue = value as EventGridEvent;
+                }
+
+                if (triggerValue == null)
+                {
+                    throw new InvalidOperationException($"Unable to bind {value} to type {_parameter.ParameterType}");
+                }
+
                 var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
                 {
                     {"data", triggerValue.Data}

--- a/test/Extension.tests/Common/FakeData.cs
+++ b/test/Extension.tests/Common/FakeData.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.Common
+{
+    public static class FakeData
+    {
+        public const string arrayOfOneEvent = @"[{
+  'topic': '/subscriptions/5b4b650e-28b9-4790-b3ab-ddbd88d727c4/resourcegroups/canaryeh/providers/Microsoft.EventHub/namespaces/canaryeh',
+  'subject': 'eventhubs/test',
+  'eventType': 'captureFileCreated',
+  'eventTime': '2017-07-14T23:10:27.7689666Z',
+  'id': '7b11c4ce-1c34-4416-848b-1730e766f126',
+  'data': {
+    'fileUrl': 'https://shunsouthcentralus.blob.core.windows.net/debugging/shunBlob.txt',
+    'fileType': 'AzureBlockBlob',
+    'partitionId': '1',
+    'sizeInBytes': 0,
+    'eventCount': 0,
+    'firstSequenceNumber': -1,
+    'lastSequenceNumber': -1,
+    'firstEnqueueTime': '0001-01-01T00:00:00',
+    'lastEnqueueTime': '0001-01-01T00:00:00'
+  },
+  'publishTime': '2017-07-14T23:10:29.5004788Z'
+}]";
+        public const string singleEvent = @"{
+  'topic': '/subscriptions/5b4b650e-28b9-4790-b3ab-ddbd88d727c4/resourcegroups/canaryeh/providers/Microsoft.EventHub/namespaces/canaryeh',
+  'subject': 'eventhubs/test',
+  'eventType': 'captureFileCreated',
+  'eventTime': '2017-07-14T23:10:27.7689666Z',
+  'id': '7b11c4ce-1c34-4416-848b-1730e766f126',
+  'data': {
+    'fileUrl': 'https://shunsouthcentralus.blob.core.windows.net/debugging/shunBlob.txt',
+    'fileType': 'AzureBlockBlob',
+    'partitionId': '1',
+    'sizeInBytes': 0,
+    'eventCount': 0,
+    'firstSequenceNumber': -1,
+    'lastSequenceNumber': -1,
+    'firstEnqueueTime': '0001-01-01T00:00:00',
+    'lastEnqueueTime': '0001-01-01T00:00:00'
+  },
+  'publishTime': '2017-07-14T23:10:29.5004788Z'
+}";
+    }
+}

--- a/test/Extension.tests/Common/FakeLocator.cs
+++ b/test/Extension.tests/Common/FakeLocator.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Extension.tests
+namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
 {
     public class FakeTypeLocator<T> : ITypeLocator
     {

--- a/test/Extension.tests/Common/TestBinding.cs
+++ b/test/Extension.tests/Common/TestBinding.cs
@@ -3,7 +3,7 @@ using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Config;
 using System;
 
-namespace Extension.tests
+namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
 {
     [Binding]
     public class BindingDataAttribute : Attribute

--- a/test/Extension.tests/Common/TestHelpers.cs
+++ b/test/Extension.tests/Common/TestHelpers.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Extension.tests
+namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
 {
     public class TestHelpers
     {

--- a/test/Extension.tests/Extension.tests.csproj
+++ b/test/Extension.tests/Extension.tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <AssemblyName>Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Extension.tests/JobhostEndToEnd.cs
+++ b/test/Extension.tests/JobhostEndToEnd.cs
@@ -3,37 +3,19 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using Xunit;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.Common;
 
-namespace Extension.tests
+namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
 {
     public class JobhostEndToEnd
     {
-        const string singleEvent = @"{
-  'topic': '/subscriptions/5b4b650e-28b9-4790-b3ab-ddbd88d727c4/resourcegroups/canaryeh/providers/Microsoft.EventHub/namespaces/canaryeh',
-  'subject': 'eventhubs/test',
-  'eventType': 'captureFileCreated',
-  'eventTime': '2017-07-14T23:10:27.7689666Z',
-  'id': '7b11c4ce-1c34-4416-848b-1730e766f126',
-  'data': {
-    'fileUrl': 'https://shunsouthcentralus.blob.core.windows.net/debugging/shunBlob.txt',
-    'fileType': 'AzureBlockBlob',
-    'partitionId': '1',
-    'sizeInBytes': 0,
-    'eventCount': 0,
-    'firstSequenceNumber': -1,
-    'lastSequenceNumber': -1,
-    'firstEnqueueTime': '0001-01-01T00:00:00',
-    'lastEnqueueTime': '0001-01-01T00:00:00'
-  },
-  'publishTime': '2017-07-14T23:10:29.5004788Z'
-}";
         static private string functionOut = null;
 
         [Fact]
         public async Task ConsumeEventGridEventTest()
         {
 
-            EventGridEvent eve = JsonConvert.DeserializeObject<EventGridEvent>(singleEvent);
+            EventGridEvent eve = JsonConvert.DeserializeObject<EventGridEvent>(FakeData.singleEvent);
             var args = new Dictionary<string, object>{
                 { "value", eve }
             };
@@ -52,7 +34,7 @@ namespace Extension.tests
         [Fact]
         public async Task UseInputBlobBinding()
         {
-            EventGridEvent eve = JsonConvert.DeserializeObject<EventGridEvent>(singleEvent);
+            EventGridEvent eve = JsonConvert.DeserializeObject<EventGridEvent>(FakeData.singleEvent);
             var args = new Dictionary<string, object>{
                 { "value", eve }
             };

--- a/test/Extension.tests/JobhostEndToEnd.cs
+++ b/test/Extension.tests/JobhostEndToEnd.cs
@@ -1,10 +1,7 @@
-﻿using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.EventGrid;
+﻿using Microsoft.Azure.WebJobs.Extensions.EventGrid;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using Xunit;
-using System.IO;
-using System;
 using System.Threading.Tasks;
 
 namespace Extension.tests

--- a/test/Extension.tests/TestListener.cs
+++ b/test/Extension.tests/TestListener.cs
@@ -13,11 +13,11 @@ using System.Net;
 using System.Text;
 using Newtonsoft.Json.Linq;
 
-namespace Extension.tests
+namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
 {
     public class TestListener : IWebHookProvider
-    { 
-    
+    {
+
         Uri IWebHookProvider.GetUrl(IExtensionConfigProvider extension)
         {
             // Called by configuration registration. URI here doesn't matter.
@@ -44,7 +44,7 @@ namespace Extension.tests
 
 
             var request = CreateUnsubscribeRequest("TestEventGrid");
-            IAsyncConverter <HttpRequestMessage, HttpResponseMessage> handler = ext;
+            IAsyncConverter<HttpRequestMessage, HttpResponseMessage> handler = ext;
             var response = await handler.ConvertAsync(request, CancellationToken.None);
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
@@ -65,11 +65,11 @@ namespace Extension.tests
 
             var request = CreateDispatchRequest("TestEventGrid", new EventGridEvent
             {
-                 Subject = "One",
-                 Data = JObject.FromObject(new FakePayload
-                 {
-                     Prop = "alpha"
-                 })
+                Subject = "One",
+                Data = JObject.FromObject(new FakePayload
+                {
+                    Prop = "alpha"
+                })
             },
             new EventGridEvent
             {
@@ -103,8 +103,8 @@ namespace Extension.tests
             var request = new HttpRequestMessage(HttpMethod.Post, "http://localhost/?functionName=" + funcName);
             request.Headers.Add("aeg-event-type", "Notification");
             request.Content = new StringContent(
-                JsonConvert.SerializeObject(items), 
-                Encoding.UTF8, 
+                JsonConvert.SerializeObject(items),
+                Encoding.UTF8,
                 "application/json");
             return request;
         }

--- a/test/Extension.tests/UnitTests.cs
+++ b/test/Extension.tests/UnitTests.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests.Common;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+using static Microsoft.Azure.WebJobs.Extensions.EventGrid.EventGridTriggerAttributeBindingProvider;
+
+namespace Microsoft.Azure.WebJobs.Extensions.EventGrid.Tests
+{
+    public class UnitTests
+    {
+        private void DummyMethod(EventGridEvent e)
+        {
+        }
+
+        [Fact]
+        public async Task bindAsyncTest()
+        {
+            MethodBase methodbase = this.GetType().GetMethod("DummyMethod", BindingFlags.NonPublic | BindingFlags.Instance);
+            ParameterInfo[] arrayParam = methodbase.GetParameters();
+
+            ITriggerBinding binding = new EventGridTriggerBinding(arrayParam[0], null, null);
+            // given GventGridEvent
+            EventGridEvent eve = JsonConvert.DeserializeObject<EventGridEvent>(FakeData.singleEvent);
+            JObject data = eve.Data;
+
+            ITriggerData triggerDataWithEvent = await binding.BindAsync(eve, null);
+            Assert.Equal(data, triggerDataWithEvent.BindingData["data"]);
+
+            ITriggerData triggerDataWithString = await binding.BindAsync(FakeData.singleEvent, null);
+            Assert.Equal(data, triggerDataWithString.BindingData["data"]);
+
+            // test invalid, batch of events
+            FormatException formatException = await Assert.ThrowsAsync<FormatException>(() => binding.BindAsync(FakeData.arrayOfOneEvent, null));
+            Assert.Equal($"Unable to parse {FakeData.arrayOfOneEvent} to {typeof(EventGridEvent)}", formatException.Message);
+
+            // test invalid, random object
+            var testObject = new TestClass();
+            InvalidOperationException invalidException = await Assert.ThrowsAsync<InvalidOperationException>(() => binding.BindAsync(testObject, null));
+            Assert.Equal($"Unable to bind {testObject} to type {arrayParam[0].ParameterType}", invalidException.Message);
+        }
+
+        private class TestClass
+        {
+            public override string ToString()
+            {
+                return "test object";
+            }
+        }
+    }
+}


### PR DESCRIPTION
this [admin api](https://github.com/Azure/azure-webjobs-sdk-script/blob/0319f65cd557a7f13ab0ed2a4d3fdec41d941b6e/src/WebJobs.Script.WebHost/Controllers/AdminController.cs#L45-L47) calls `bindasync` with user's json string. so I need to add parsing and error handling
looking at what other `bindasync` is doing, they are calling a [converter](https://github.com/Azure/azure-webjobs-sdk/blob/663a508e8a851629c26a51e7de3af36629dfd120/src/Microsoft.Azure.WebJobs.Host/Converters/CompositeObjectToTypeConverter.cs#L13)
```
public async Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
        {
            BrokeredMessage message = value as BrokeredMessage;
            if (message == null && !_converter.TryConvert(value, out message))
            {
                throw new InvalidOperationException("Unable to convert trigger to BrokeredMessage.");
            }

```
but this interface is `internal` so my choices are limited