### PR TITLE
Register WebHook listener earlier

### DIFF
--- a/src/EventGridExtension/EventGridExtension.csproj
+++ b/src/EventGridExtension/EventGridExtension.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.EventGrid</PackageId>
     <Description>This extension adds bindings for EventGrid</Description>
-    <Version>1.0.0$(VersionSuffix)</Version>
+    <Version>1.0.1$(VersionSuffix)</Version>
     <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.EventGrid</AssemblyName>

--- a/src/EventGridExtension/EventGridListener.cs
+++ b/src/EventGridExtension/EventGridListener.cs
@@ -16,28 +16,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
             _listenersStore = listenersStore;
             _functionName = functionName;
             Executor = executor;
+
+            // Register the listener as part of create time initialization
+            _listenersStore.AddListener(_functionName, this);
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            _listenersStore.AddListener(_functionName, this);
             return Task.FromResult(true);
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            // calling order stop -> cancel -> dispose
             return Task.FromResult(true);
         }
 
         public void Dispose()
         {
-            // TODO unsubscribe
         }
 
         public void Cancel()
         {
-            // TODO cancel any outstanding tasks initiated by this listener
         }
     }
 }


### PR DESCRIPTION
Part of the fix for https://github.com/Azure/azure-functions-host/issues/4021

I do see that MIcrosoft Graph extension also has this issue ([here](https://github.com/Azure/azure-functions-microsoftgraph-extension/blob/265ede3da9ac3dbe61c3d3ff49178e808689f048/src/MicrosoftGraphBinding/Bindings/WebhookTriggerListener.cs#L38)). Since that binding is in preview, perhaps nobody has been noticing race conditions? @ConnorMcMahon 