### PR TITLE
Register WebHook listener earlier

### DIFF
--- a/src/EventGridExtension/TriggerBinding/EventGridListener.cs
+++ b/src/EventGridExtension/TriggerBinding/EventGridListener.cs
@@ -12,37 +12,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
         public ITriggeredFunctionExecutor Executor { private set; get; }
         public readonly bool SingleDispatch;
 
-        private EventGridExtensionConfigProvider _extensionConfigProvider;
+        private EventGridExtensionConfigProvider _listenersStore;
         private readonly string _functionName;
 
         public EventGridListener(ITriggeredFunctionExecutor executor, EventGridExtensionConfigProvider listenersStore, string functionName, bool singleDispatch)
         {
-            _extensionConfigProvider = listenersStore;
+            _listenersStore = listenersStore;
             _functionName = functionName;
             SingleDispatch = singleDispatch;
             Executor = executor;
+
+            // Register the listener as part of create time initialization
+            _listenersStore.AddListener(_functionName, this);
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            _extensionConfigProvider.AddListener(_functionName, this);
             return Task.FromResult(true);
         }
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            // calling order stop -> cancel -> dispose
             return Task.FromResult(true);
         }
 
         public void Dispose()
         {
-            // TODO unsubscribe
         }
 
         public void Cancel()
         {
-            // TODO cancel any outstanding tasks initiated by this listener
         }
     }
 }


### PR DESCRIPTION
We made this fix in v1, but never merged to v2. See https://github.com/Azure/azure-functions-eventgrid-extension/pull/65