### PR TITLE
improve property xml comments

### DIFF
--- a/src/EventGridExtension/OutputBinding/EventGridAttribute.cs
+++ b/src/EventGridExtension/OutputBinding/EventGridAttribute.cs
@@ -12,13 +12,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventGrid
     [Binding]
     public sealed class EventGridAttribute : Attribute
     {
-        /// <summary>Gets or sets the topic events endpoint URI. Eg: https://topic1.westus2-1.eventgrid.azure.net/api/events 
-        /// This is found in the Event Grid Topic's definition. You can find information on getting the Url for a topic here: https://docs.microsoft.com/en-us/azure/event-grid/custom-event-quickstart#send-an-event-to-your-topic
+        /// <summary>
+        /// Gets or sets the Topic endpoint URI setting.
+        /// You can find information on getting the Url for a topic here: https://docs.microsoft.com/en-us/azure/event-grid/custom-event-quickstart#send-an-event-to-your-topic
         /// </summary>
         [AppSetting]
         public string TopicEndpointUri { get; set; }
 
-        /// <summary>Gets or sets the Topic Key setting. You can find information on getting the Key for a topic here: https://docs.microsoft.com/en-us/azure/event-grid/custom-event-quickstart#send-an-event-to-your-topic </summary>
+        /// <summary>
+        /// Gets or sets the Topic Key setting.
+        /// You can find information on getting the Key for a topic here: https://docs.microsoft.com/en-us/azure/event-grid/custom-event-quickstart#send-an-event-to-your-topic 
+        /// </summary>
         [AppSetting]
         public string TopicKeySetting { get; set; }
     }


### PR DESCRIPTION
In response to an internal thread, this improves the XML comments around `TopicEndpointUri` of the output binding to direct users that it's an app setting key which should go as the value here, not the actual URI or the `%%` nomenclature